### PR TITLE
Rich types classes feature toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "anyhow",
  "common_errors",
  "derive_more",
+ "domain_mobile",
  "domain_schedule_models",
  "env_logger",
  "envmnt",
@@ -612,6 +613,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "domain_mobile"
+version = "0.1.0"
+
+[[package]]
 name = "domain_schedule"
 version = "0.1.0"
 dependencies = [
@@ -733,6 +738,7 @@ name = "feature_schedule"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "domain_mobile",
  "domain_schedule",
  "domain_schedule_models",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "common_errors",
   "common_in_memory_cache",
   "common_persistent_cache",
+  "domain_mobile",
   "domain_schedule",
   "domain_schedule_models",
   "domain_schedule_shift",

--- a/app_schedule/Cargo.toml
+++ b/app_schedule/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Anton Kolomeytsev <tonykolomeytsev@gmail.com>"]
 
 [dependencies]
 common_errors = { path = "../common_errors" }
+domain_mobile = { path = "../domain_mobile" }
 domain_schedule_models = { path = "../domain_schedule_models" }
 feature_schedule = { path = "../feature_schedule" }
 

--- a/domain_mobile/Cargo.toml
+++ b/domain_mobile/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "domain_mobile"
+version = "0.1.0"
+edition = "2021"
+authors = ["Anton Kolomeytsev <tonykolomeytsev@gmail.com>"]

--- a/domain_mobile/src/app_version.rs
+++ b/domain_mobile/src/app_version.rs
@@ -1,0 +1,121 @@
+use std::{cmp::Ordering, collections::VecDeque, fmt::Display, num::ParseIntError, str::FromStr};
+
+#[derive(Debug, Clone)]
+pub struct AppVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+}
+
+impl Display for AppVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    PartParsingError(ParseIntError),
+    WrongPartsNumber,
+}
+
+impl FromStr for AppVersion {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s
+            .split('.')
+            .map(|it| it.parse::<u16>())
+            .collect::<Result<VecDeque<u16>, _>>()
+            .map_err(Error::PartParsingError)?;
+
+        if parts.len() != 3 {
+            return Err(Error::WrongPartsNumber);
+        }
+
+        Ok(Self {
+            major: parts.pop_front().unwrap(),
+            minor: parts.pop_front().unwrap(),
+            patch: parts.pop_front().unwrap(),
+        })
+    }
+}
+
+impl Ord for AppVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.major.cmp(&other.major) {
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Less => return Ordering::Less,
+            _ => (),
+        }
+        match self.minor.cmp(&other.minor) {
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Less => return Ordering::Less,
+            _ => (),
+        }
+        match self.patch.cmp(&other.patch) {
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Less => return Ordering::Less,
+            _ => (),
+        }
+        Ordering::Equal
+    }
+}
+
+impl PartialOrd for AppVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for AppVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.major == other.major && self.minor == other.minor && self.patch == other.patch
+    }
+}
+
+impl Eq for AppVersion {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::WrongPartsNumber => write!(
+                f,
+                "Version should consist of three parts: major.minor.patch"
+            ),
+            Error::PartParsingError(err) => write!(f, "Version parsing error: {err}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AppVersion;
+
+    #[test]
+    fn test_parsing() {
+        for major in 1..10 {
+            for minor in 1..20 {
+                for patch in 1..30 {
+                    let version_name = format!("{major}.{minor}.{patch}");
+                    let app_version = version_name.parse::<AppVersion>();
+                    assert!(app_version.is_ok());
+                    assert_eq!(version_name, app_version.unwrap().to_string());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_comparison() {
+        let v1_11 = "1.11.0".parse::<AppVersion>().unwrap();
+        let v1_10 = "1.10.3".parse::<AppVersion>().unwrap();
+        let v1_12 = "1.12.0".parse::<AppVersion>().unwrap();
+        let v2_00 = "2.0.2".parse::<AppVersion>().unwrap();
+
+        assert!(v1_11 > v1_10);
+        assert!(v1_10 < v1_12);
+        assert!(v1_12 < v2_00);
+        assert!(v2_00 > v1_11);
+    }
+}

--- a/domain_mobile/src/lib.rs
+++ b/domain_mobile/src/lib.rs
@@ -1,0 +1,2 @@
+mod app_version;
+pub use app_version::*;

--- a/domain_schedule/src/schedule/mapping.rs
+++ b/domain_schedule/src/schedule/mapping.rs
@@ -80,6 +80,10 @@ fn get_classes_type(raw_type: &str) -> ClassesType {
         ClassesType::Practice
     } else if raw_type.contains("курс") || raw_type.contains("кп") {
         ClassesType::Course
+    } else if raw_type.contains("экз") {
+        ClassesType::Exam
+    } else if raw_type.contains("консул") {
+        ClassesType::Consultation
     } else {
         ClassesType::Undefined
     }

--- a/feature_schedule/Cargo.toml
+++ b/feature_schedule/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Anton Kolomeytsev <tonykolomeytsev@gmail.com>"]
 
 [dependencies]
+domain_mobile = { path = "../domain_mobile" }
 domain_schedule = { path = "../domain_schedule" }
 domain_schedule_models = { path = "../domain_schedule_models" }
 

--- a/feature_schedule/src/v1.rs
+++ b/feature_schedule/src/v1.rs
@@ -5,9 +5,7 @@ use domain_schedule::{
         GetScheduleIdUseCase, GetScheduleUseCase, InitDomainScheduleUseCase, SearchScheduleUseCase,
     },
 };
-use domain_schedule_models::dto::v1::{
-    Classes, ClassesType, Schedule, ScheduleSearchResult, ScheduleType,
-};
+use domain_schedule_models::dto::v1::{ClassesType, Schedule, ScheduleSearchResult, ScheduleType};
 
 pub struct FeatureSchedule(
     GetScheduleIdUseCase,

--- a/feature_schedule/src/v1.rs
+++ b/feature_schedule/src/v1.rs
@@ -1,10 +1,13 @@
+use domain_mobile::AppVersion;
 use domain_schedule::{
     di::DomainScheduleModule,
     usecases::{
         GetScheduleIdUseCase, GetScheduleUseCase, InitDomainScheduleUseCase, SearchScheduleUseCase,
     },
 };
-use domain_schedule_models::dto::v1::{Schedule, ScheduleSearchResult, ScheduleType};
+use domain_schedule_models::dto::v1::{
+    Classes, ClassesType, Schedule, ScheduleSearchResult, ScheduleType,
+};
 
 pub struct FeatureSchedule(
     GetScheduleIdUseCase,
@@ -35,8 +38,29 @@ impl FeatureSchedule {
         name: String,
         r#type: ScheduleType,
         offset: i32,
+        app_version: Option<AppVersion>,
     ) -> anyhow::Result<Schedule> {
-        self.1.get_schedule(name, r#type, offset).await
+        let mut schedule = self.1.get_schedule(name, r#type, offset).await?;
+
+        // for backward compatibility with old mpeix apps
+        if let Some(mpeix_version) = app_version {
+            // if it is 1.X.X version ...
+            if mpeix_version.major < 2 {
+                // replace all rich classes types to Undefined,
+                // to prevent crashes on mobile
+                schedule
+                    .weeks
+                    .iter_mut()
+                    .flat_map(|week| week.days.iter_mut())
+                    .flat_map(|day| day.classes.iter_mut())
+                    .filter(|class| {
+                        matches!(class.r#type, ClassesType::Exam | ClassesType::Consultation)
+                    })
+                    .for_each(|class| class.r#type = ClassesType::Undefined);
+            }
+        }
+
+        Ok(schedule)
     }
 
     pub async fn search_schedule(


### PR DESCRIPTION
Для приложений версии 1.X.X количество возвращаемых типов пар меньше, чем для всех остальных. Сделано это для обратной совместимости, чтоб приложения старых версий не падали от ответов сервера. Приложения, начиная с версии 2.0.0 будет поддерживать новые типы пар.